### PR TITLE
Adding ANSI colours and small changes to ljinux source

### DIFF
--- a/code.py
+++ b/code.py
@@ -10,6 +10,7 @@
 #
 
 from sys import exit
+from src_py.lj_colours import lJ_Colours as LJC
 
 try:
     from os import chdir, sync
@@ -20,12 +21,18 @@ try:
         RunMode,
         on_next_reset
     )
-    
+
+
     from gc import collect
     from time import sleep
+<<<<<<< Updated upstream
     
 except ImportError:
     print("bootloader failure")
+=======
+except ImportError as e:
+    print(LJC.ERROR + "bootloader failure" + LJC.ENDC, e)
+>>>>>>> Stashed changes
     exit(0)
     
 
@@ -38,7 +45,7 @@ try:
     from ljinux import ljinux
     jrub("Ljinux basic init done")
 except ImportError:
-    jrub("Ljinux wanna-be kernel binary not found, cannot continue..") # anon is idot, we not gonna bother
+    jrub("Ljinux wanna-be kernel binary not found, cannot continue..")
     exit(1)
 
 oss = ljinux()
@@ -94,7 +101,7 @@ if (Exit_code == 245):
     reset()
     
 elif (Exit_code == 244):
-    print("[ OK ] Reached target: Halt")
+    print(LJC.OKAY + "[ OK ] Reached target: Halt" + LJC.ENDC)
     while True:
         sleep(3600)
         

--- a/source/ljinux_source.py
+++ b/source/ljinux_source.py
@@ -362,7 +362,7 @@ if not configg["fixrtc"]:
         dmtex("CRITICAL: RTC LIBRARIES LOADING FAILED")
 dmtex("Imports complete")
 
-class ljinux():
+class ljinux:
     class history:
         historyy = []
         
@@ -390,6 +390,9 @@ class ljinux():
         def save(filen):
             ljinux.io.led.value = False
             try:
+
+                # use r+ instead of all of this please.
+
                 # File unused but I need to check it's existence
                 a = open(filen, 'r')
                 a.close()
@@ -415,7 +418,7 @@ class ljinux():
                 a.close()
                 with open(filen, 'w') as historyfile:
                     historyfile.flush()
-                ljinux.history.historyy = []
+                ljinux.history.historyy.clear()
             except OSError:
                     ljinux.based.error(4,filen)
             ljinux.io.led.value = True
@@ -423,9 +426,12 @@ class ljinux():
         def gett(whichh): # get a specific history item, from loaded history
             return str(ljinux.history.historyy[len(ljinux.history.historyy) - whichh])
 
-        def getall(): # get the whole history, numbered, line by line
-            for i in range(len(ljinux.history.historyy)):
-                print(str(i+1) + ": " + str(ljinux.history.historyy[i]))
+        def getall():
+            """
+                History
+            """
+            for index, content in enumerate(1, len(ljinux.history.historyy)):
+                print(index + ":", str(content))
 
     class SerialReader:
         """
@@ -544,7 +550,6 @@ class ljinux():
                         badchar = True
                     elif (hexed == "0xf"): # Catch Ctrl + O for debug
                         print("\n" + "-" * 12)
-
                         print("self.pos = {}".format(self.pos))
                         print("self.s = {}".format(self.s))
                         print("self.scount = {}".format(self.scount))
@@ -775,10 +780,9 @@ class ljinux():
                     r = requests.get("http://worldtimeapi.org/api/timezone/Europe/Athens")
                     dat = r.json()
                     dmtex("Public IP: " + dat["client_ip"])
-                    if (dat["dst"] == "True"):
-                        dst = 1
-                    else:
-                        dst = 0
+
+                    dst = 1 if dat["dst"] == "True" else 0
+
                     nettime = time.struct_time((int(dat["datetime"][:4]),int(dat["datetime"][5:7]),int(dat["datetime"][8:10]),int(dat["datetime"][11:13]),int(dat["datetime"][14:16]),int(dat["datetime"][17:19]),int(dat["day_of_week"]),int(dat["day_of_year"]),dst))
                     rtcc.write_datetime(nettime)
                     del nettime
@@ -793,7 +797,7 @@ class ljinux():
         def test():
             if ljinux.io.network_online and not ljinux.io.network.link_status:
                 ljinux.io.network_online = False
-                ljinux.io.network_name = "Offiline"
+                ljinux.io.network_name = "Offline"
                 dmtex("Network connection lost")
                 return False
             return True

--- a/src_py/lj_colours.py
+++ b/src_py/lj_colours.py
@@ -1,0 +1,50 @@
+
+class lJ_Colours:
+    """
+         Adding colours to lJinux !
+    """
+
+    """
+    Main
+    """
+    OKAY = "\033[92m"
+    WARNING = "\033[93m"
+    ERROR = "\033[91m"
+
+    """
+        Other tools
+    """
+
+    CLEAR_S = '\033[23'
+    M_MOUSE_TL = '\033[H'
+    M_MOUSE_TO = '\033[r;cH' # Mouse index starts at 1
+
+    HIDE_M = "\033[?25l"
+    DEL_FROM_M_TILL_ENDLINE = "1033[K"
+
+    """
+        Styling
+    """
+    UNDERLINE = "1033[4m"
+    BOLD = '\033[1m'
+    ENDC = "\033[0m"
+
+    """
+        Okay
+    """
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+
+    """
+        Coloured Text
+    """
+    RESET_S_FORMAT = "\033[0m"
+    BLACK_T = "1033[30m"
+    RED_T = "\033[31m"
+    GREEN_T = "\033[32m"
+    YELLOW_T = "\033[33m"
+    BLUE_T = "\033[34m"
+    MAGENTA_T = "\033[35m"
+    CYAN_T = "\033[36m"
+    WHITE_T = "\033[37m"
+


### PR DESCRIPTION
- Fixed typo in network class
`Offiline` instead of `Offline` :eyes:

- simplified `getall()` by doing enumeration

Check if the colours and enum are working before merging, I put 2 tests in bootloader failure and  exit code 224

Any new tools / reworks will be put in the `src_py` that I made.