### PR TITLE
Found bloat, script re-structured for convenience

### DIFF
--- a/rootfilesystem/code.py
+++ b/rootfilesystem/code.py
@@ -1,55 +1,67 @@
-def jrub(texx=None):  # basic logging for the launcher
-    print("jrub> ", texx)
+from sys import exit
+from microcontroller import reset, RunMode, on_next_reset
+from time import sleep
 
+exit_l = {
+    0: lambda: (jrub("Exiting"), exit(0)),
+    1: lambda: (jrub("Exiting due to error"), exit(1)),
+    241: lambda: (on_next_reset(RunMode.UF2), reset()),
+    242: lambda: (on_next_reset(RunMode.SAFE_MODE), reset()),
+    243: lambda: (on_next_reset(RunMode.BOOTLOADER), reset()),
+    244: lambda: (jrub("Reached target: Halt"), sleep(36000)),
+    245: lambda: reset(),
+}
+
+jrub = lambda text: print(f"jrub> {text}")
 
 try:
-    from ljinux import ljinux
-
+    import ljinux
     jrub("Ljinux basic init done")
 except ImportError:
     jrub("Ljinux wanna-be kernel binary not found, cannot continue..")
-    from sys import exit
+    exit_l[1]()
 
-    exit(1)
-oss = ljinux()
-jrub(
-    "Ljinux object init complete"
-)  # the init of the basic os structure is done then this runs too
+oss = ljinux.ljinux()
+
+jrub("Ljinux object init complete") 
 
 oss.farland.setup()
-jrub("Display init complete")  # even if no display is attached, this init is necessary
+
+jrub("Display init complete") 
+
 oss.io.init_net()
-jrub(
-    "Net init complete"
-)  # same goes for this, if the objects are not here, the commands will break
+
+jrub("Net init complete")
+
 if oss.io.network_online:
     jrub("Network up")
     oss.networking.timeset()
     jrub("Time set complete")
 else:
     jrub("Network down")
+
 oss.farland.frame()
-jrub(
-    "Running Ljinux autorun.."
-)  # the autorun is basically everything run and managed by ljinux itself
+
+jrub("Running Ljinux autorun..")
+
 try:
-    Exit_code = (
-        oss.based.autorun()
-    )  # when this is done, the shell exited fully and we can pack up if exit code is something reasonable
-    jrub("Shell exited with exit code " + str(Exit_code))
+    Exit_code = (oss.based.autorun())  
+    jrub(f"Shell exited with exit code {Exit_code}")
 except EOFError:
     jrub("\nAlert: Serial Ctrl + D caught, exiting\n")
-    Exit_code = 0
+    exit_l[0]()
+
 except Exception as err:
-    print("\n\nLjinux crashed with:\t" + str(type(err))[8:-2] + ": " + str(err))
+    print(f"\n\nLjinux crashed with:\t {str(type(err))[8:-2]}: {err}")
     del err
-    Exit_code = 1
+    exit_l[1]()
+
 oss.io.ledset(0)  # idle
 
 oss.farland.clear()
 jrub("Cleared display")
 
-oss.history.save(ljinux.based.user_vars["history-file"])
+oss.history.save(oss.based.user_vars["history-file"])
 jrub("History flushed")
 
 from os import chdir, sync
@@ -64,30 +76,16 @@ oss.io.led.value = True
 try:
     oss.io.led.value = False
     from storage import umount
-
     umount("/ljinux")
     jrub("Unmounted /ljinux")
     oss.io.led.value = True
-except OSError as os_err:
+    
+except OSError:
     jrub("Could not unmount /ljinux")
 
 jrub("Reached target: Quit")
 oss.io.led.value = False
 del oss
-
-from sys import exit
-from microcontroller import reset, RunMode, on_next_reset
-from time import sleep
-
-exit_l = {
-    0: lambda: jrub("Exiting"),
-    1: lambda: jrub("Exiting due to error"),
-    241: lambda: (on_next_reset(RunMode.UF2), reset()),
-    242: lambda: (on_next_reset(RunMode.SAFE_MODE), reset()),
-    243: lambda: (on_next_reset(RunMode.BOOTLOADER), reset()),
-    244: lambda: (jrub("Reached target: Halt"), sleep(36000)),
-    245: lambda: reset(),
-}
 
 exit_l[Exit_code]()
 exit(Exit_code)


### PR DESCRIPTION
* `def jrub` 
   * None default value is not required because programmer is not checking for value types
   * its single print line, can easily be replaced by lambda
* Added more f-strings
* changed bad OOP practice `ljinux.based.user_vars["history-file"]` to `oss.based.user_vars["history-file"]`

We should turn `exit_l` into a new module and use it in the whole project
* it will reduce `from sys import exit ,  exit(1)` spam
* reduce other module spam
* code.py will get even more minimal