### PR TITLE
add rx/tx to board imports

### DIFF
--- a/source/pintab_adafruit_feather_esp32s2.py
+++ b/source/pintab_adafruit_feather_esp32s2.py
@@ -20,6 +20,8 @@ from board import (
     D9,
     D6,
     D5,
+    RX,
+    TX
 )
 
 pintab = {
@@ -45,5 +47,5 @@ pintab = {
     36: SCK,
     37: MISO,
     38: RX,
-    39: TX,
+    39: TX
 }


### PR DESCRIPTION
I tested windows install using the esp32s2pico branch and this seems to be the only issue that blocked ljinux from loading.

I am getting the following message:

     [    6.84106] Unknown board. Please open an issue in https://github.com/bill88t/ljinux

But I was getting that before and it doesn't seem to be fatal :)