### PR TITLE
Add prompt to create web workflow .env file

### DIFF
--- a/scripts/copy_rootfs.py
+++ b/scripts/copy_rootfs.py
@@ -31,6 +31,7 @@ if picop == "":
     exit(1)
 
 if uname().system == "Linux":
+    slash = "/"
     if system(f"test -d {picop}/LjinuxRoot") != 0:
         print("Created LjinuxRoot")
         mkdir(f"{picop}/LjinuxRoot")
@@ -39,7 +40,57 @@ if uname().system == "Linux":
     print(f"cp -v ../Manual.txt {picop}/LjinuxRoot/home/pi/")
     system(f"cp -v ../Manual.txt {picop}/LjinuxRoot/home/pi/")
 else:
+    slash = "\\"
     print(f"xcopy /y/s ..\\LjinuxRoot\\* {picop}\\LjinuxRoot\\")
     system(f"xcopy /y/s ..\\LjinuxRoot\\* {picop}\\LjinuxRoot\\")
     print(f"copy ..\\Manual.txt {picop}\\LjinuxRoot\\home\\pi\\")
     system(f"copy ..\\Manual.txt {picop}\\LjinuxRoot\\home\\pi\\")
+
+ans = ""
+while ans != "Y" and ans != "N":
+    ans = input("Does the target microcontroller support wifi (Y/N): ").upper()
+    if ans != "Y" and ans != "N":
+        print("Invalid response, please answer Y, or N")
+
+if ans == "Y":
+    envline = {}
+    paramlist = ['CIRCUITPY_WIFI_SSID','CIRCUITPY_WIFI_PASSWORD','CIRCUITPY_WEB_API_PASSWORD']
+
+    defaults = True
+    try:
+        envfile = open(picop+slash+'.env')
+    except:
+        defaults = False
+
+    if defaults:
+        for line in envfile:
+            try:
+                envline[line.split('=')[0].strip()] = line.split('=')[1].strip()
+            except:
+                pass
+        envfile.close()
+
+    ans = ""
+    while ans.upper() != "Y" and ans.upper() != "A":
+
+        for param in paramlist:
+            temp = input(param+": ["+envline.get(param,"")+"] ")
+            if temp != "":
+                envline[param] = temp
+
+        print("\n"+slash+".env file about to be created:\n")
+        for param in paramlist:
+            print(param+"="+envline.get(param,""))
+
+        print()
+        ans = ""
+        while ans.upper() != "Y" and ans.upper() != "N" and ans.upper() != "A":
+            ans = input("Does this look correct (Y/N/(A)bort)?: ")
+            if ans.upper() != "Y" and ans.upper() != "N" and ans.upper() != "A":
+                print("Invalid response, please answer Y, N or A")
+
+    if ans.upper() != "A":
+        envfile = open(picop+slash+'.env','w')
+        for param in paramlist:
+            envfile.write(param+"="+envline.get(param,"")+"\n")
+        envfile.close()


### PR DESCRIPTION
Just thought I'd throw this out there, creating a .env file on boards that support WiFi allows you to access the contents of the microcontroller board without having to go into "devmode". There's also the added benefit of accessing the ljinux console over the Web Workflow serial terminal.

The .env file can obviously be added onto the board before or after the ljinux install but I thought it might be convenient to have it created during the install. This does add an input prompt to the install process which you may not be interested in doing.