### PR TITLE
Remove the workaround for ealy usb connetions

### DIFF
--- a/LjinuxRoot/bin/bufferclear.lja
+++ b/LjinuxRoot/bin/bufferclear.lja
@@ -1,1 +1,0 @@
-pexec term.clear_buffer()

--- a/bootcfg/Init.lja
+++ b/bootcfg/Init.lja
@@ -8,9 +8,6 @@ fpexec /LjinuxRoot/etc/hostname-reload.py
 # wait for connection
 _waitforconnection
 
-# optional buffer clear
-bufferclear
-
 # fancy title
 fpexec /bin/ljinuxtitle.py
 


### PR DESCRIPTION
No longer needed, as https://github.com/adafruit/circuitpython/issues/6892 is fixed through https://github.com/adafruit/circuitpython/pull/7041.